### PR TITLE
Add OANDA balance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains simple example scripts for MetaTrader 5.
 
 - **CryptoRiskCalculator.mq5** – calculates risk for crypto trades and saves the result to a text file.
 - **scripts/FXScanner.mq5** – scans FX symbols across timeframes and exports several CSV files.
-- **scripts/PositionSizeFX.mq5** – calculates forex position size with adjustable risk settings.
+- **scripts/PositionSizeFX.mq5** – calculates forex position size with adjustable risk settings. You can now choose whether the calculations use your Pepperstone balance or a manual OANDA balance.
 - **AUD_EMA_TraderEA.mq5** – simple EMA-based expert advisor example.
 
 Copy the `.mq5` files to your `MQL5\Scripts` folder to use them in MT5.

--- a/scripts/PositionSizeFX.mq5
+++ b/scripts/PositionSizeFX.mq5
@@ -28,14 +28,24 @@ enum ENUM_ORDER_SIDE
    ORDER_SELL = 1
 };
 
+enum ENUM_BALANCE_MODE
+{
+   BALANCE_PEPPERSTONE = 0,
+   BALANCE_OANDA       = 1
+};
+
 //--- Inputs
 input ENUM_RISK_MODE   RiskMode           = RISK_FIXED_PERCENT;
 input double           FixedRiskAmountAUD = 100.0;
 input double           RiskPercentage     = 1.0;
 input double           StopLossPips       = 20.0;
 input ENUM_BROKER_MODE BrokerMode         = BROKER_PEPPERSTONE;
+input ENUM_BALANCE_MODE BalanceMode       = BALANCE_PEPPERSTONE;
 input double           RewardRiskRatio    = 2.0;
 input ENUM_ORDER_SIDE  OrderSide          = ORDER_BUY;
+
+input double           PepperstoneBalance = 0.0; // manually set if BalanceMode = BALANCE_PEPPERSTONE
+input double           OandaBalance       = 0.0; // manually set if BalanceMode = BALANCE_OANDA
 
 //--- Extra adjustable parameters
 input double           CommissionPerLot   = 7.0;     // Commission for 1 lot (AUD)
@@ -49,6 +59,16 @@ void OnStart()
 {
    string symbol   = _Symbol;
    double balance  = AccountInfoDouble(ACCOUNT_BALANCE);
+   if(BalanceMode == BALANCE_OANDA)
+   {
+      if(OandaBalance > 0)
+         balance = OandaBalance;
+   }
+   else // BALANCE_PEPPERSTONE
+   {
+      if(PepperstoneBalance > 0)
+         balance = PepperstoneBalance;
+   }
    if(balance <= 0)
    {
       Print("Error: invalid account balance");


### PR DESCRIPTION
## Summary
- enhance PositionSizeFX script with a setting to pick Pepperstone or OANDA account balance
- allow manual balance values for either broker
- document new capability in README

## Testing
- `apt-get update`
- `apt-cache search mql5`

------
https://chatgpt.com/codex/tasks/task_e_6843c5e14c1883219028e8ad83edd994