### PR TITLE
Add OANDA balance API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ This repository contains simple example scripts for MetaTrader 5.
 
 - **CryptoRiskCalculator.mq5** – calculates risk for crypto trades and saves the result to a text file.
 - **scripts/FXScanner.mq5** – scans FX symbols across timeframes and exports several CSV files.
-- **scripts/PositionSizeFX.mq5** – calculates forex position size with adjustable risk settings.
+- **scripts/PositionSizeFX.mq5** – calculates forex position size with adjustable risk settings. It can fetch your OANDA balance using an API token or fall back to your Pepperstone balance.
+  - Use `BalanceMode` to choose which balance is used: `BALANCE_PEPPERSTONE` or `BALANCE_OANDA`.
+  - When using the OANDA mode, set `OandaAccountID` and `OandaApiToken` so the script can retrieve your balance. If the request fails you can provide `OandaBalance` manually.
+  - For Pepperstone you can also supply `PepperstoneBalance` manually.
 - **AUD_EMA_TraderEA.mq5** – simple EMA-based expert advisor example.
 
 Copy the `.mq5` files to your `MQL5\Scripts` folder to use them in MT5.


### PR DESCRIPTION
## Summary
- let PositionSizeFX script read OANDA balance from REST API when details are provided
- keep Pepperstone balance option as a fallback
- explain how to select the balance mode in README
- embed default OANDA credentials in `PositionSizeFX.mq5`

## Testing
- `apt-get update`
- `apt-cache search mql5`
- `apt-cache search mql`


------
https://chatgpt.com/codex/tasks/task_e_6843c5e14c1883219028e8ad83edd994