### PR TITLE
Fix compile error in PositionSizeFX

### DIFF
--- a/PositionSizeFX.mq5
+++ b/PositionSizeFX.mq5
@@ -57,7 +57,7 @@ input double           MaxTPMultiple      = 10.0;    // Maximum TP multiple allo
 //--- Determine leverage tier for Pepperstone symbols
 double GetPepperstoneLeverage(string symbol)
   {
-     string sym = StringUpper(symbol);
+     string sym = StringToUpper(symbol);
 
      // major currency pairs 30:1
      if(StringFind(sym,"USD")>=0 &&


### PR DESCRIPTION
## Summary
- fix compile error by changing `StringUpper` to `StringToUpper`

## Testing
- `apt-cache search mql5 | head`


------
https://chatgpt.com/codex/tasks/task_e_68481e1f322883219780bd45308359ef