### PR TITLE
Fix StringToUpper usage

### DIFF
--- a/PositionSizeFX.mq5
+++ b/PositionSizeFX.mq5
@@ -57,7 +57,8 @@ input double           MaxTPMultiple      = 10.0;    // Maximum TP multiple allo
 //--- Determine leverage tier for Pepperstone symbols
 double GetPepperstoneLeverage(string symbol)
   {
-     string sym = StringToUpper(symbol);
+     string sym = symbol;      // copy symbol so we can modify it
+     StringToUpper(sym);       // converts sym to uppercase
 
      // major currency pairs 30:1
      if(StringFind(sym,"USD")>=0 &&


### PR DESCRIPTION
## Summary
- fix `StringToUpper` call so symbol string is properly converted to uppercase

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_68481fe1d5508321ac5ad4bf799721e5