### PR TITLE
Fix invalid file name for PositionSizeFX script

### DIFF
--- a/PositionSizeFX.mq5
+++ b/PositionSizeFX.mq5
@@ -232,6 +232,9 @@ void OnStart()
 
    //--- build output
    string timeStamp   = TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS);
+   //--- sanitize timestamp for file name
+   timeStamp = StringReplace(timeStamp, ":", "-");
+   timeStamp = StringReplace(timeStamp, " ", "_");
    string fileName    = StringFormat("PositionSizeOutput-%s.txt", timeStamp);
 
    string out = "=== Position Size Calculation ===\n";


### PR DESCRIPTION
## Summary
- sanitize timestamp when creating filenames to avoid invalid characters

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684821f4c954832193ec461875df0b06