### PR TITLE
Fix invalid characters for FXScanner folder names

### DIFF
--- a/FXScanner.mq5
+++ b/FXScanner.mq5
@@ -29,14 +29,25 @@ ENUM_TIMEFRAMES timeframes[] =
 };
 
 //+------------------------------------------------------------------+
+//| Replace characters not allowed in Windows file or folder names    |
+//+------------------------------------------------------------------+
+void SanitizeForWindows(string &text)
+{
+    const string invalid = "\\/:*?\"<>|";
+    for(int i = 0; i < StringLen(invalid); i++)
+        StringReplace(text, StringSubstr(invalid, i, 1), "-");
+    StringReplace(text, ":", "-");
+    StringReplace(text, ".", "-");
+    StringReplace(text, " ", "_");
+}
+
+//+------------------------------------------------------------------+
 //| Create a new folder with timestamp                               |
 //+------------------------------------------------------------------+
 string CreateTimestampedFolder()
 {
     string stamp = TimeToString(TimeCurrent(), TIME_DATE|TIME_MINUTES);
-    StringReplace(stamp, ":", "-");
-    StringReplace(stamp, ".", "-");
-    StringReplace(stamp, " ", "_");
+    SanitizeForWindows(stamp);
     string base = TerminalInfoString(TERMINAL_DATA_PATH) + "\\MQL5\\Files\\FXScan_" + stamp;
     if(!FolderCreate(base))
         Print("Failed to create folder ", base, ". Error: ", GetLastError());


### PR DESCRIPTION
## Summary
- sanitize timestamp string for Windows folder names in FXScanner

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a9979e2e883219c7e39d2aa625b22