### PR TITLE
Fix pipValue calculation in EMA Trader EA

### DIFF
--- a/EMA_TraderEA.mq5
+++ b/EMA_TraderEA.mq5
@@ -131,13 +131,15 @@ double CalculateLotSize()
 
    double tickValue = SymbolInfoDouble(currentSymbol, SYMBOL_TRADE_TICK_VALUE);
    double tickSize  = SymbolInfoDouble(currentSymbol, SYMBOL_TRADE_TICK_SIZE);
+   int    digits    = (int)SymbolInfoInteger(currentSymbol, SYMBOL_DIGITS);
    if(tickValue <= 0 || tickSize <= 0)
      {
       Print("Invalid tick data.");
       return(0.0);
      }
 
-   double pipValue = tickValue / (tickSize / _Point);
+   double pipSize  = MathPow(10.0, -digits + 1);
+   double pipValue = tickValue * pipSize / tickSize;
    double slPips   = UseATRStopLoss ? (double)CalculateATRPoints() / 10.0 : StopLoss_Pips;
    double riskPerLot = slPips * pipValue;
    double rawLots = MinRiskAUD / riskPerLot;


### PR DESCRIPTION
## Summary
- correct pip value calculation so `MinRiskAUD` isn't multiplied by 10

## Testing
- `git status --short`
- `which mql5compiler` *(fails: no compiler in container)*

------
https://chatgpt.com/codex/tasks/task_e_684dedb874548321bb665368980d7544