### PR TITLE
Fix compile errors in EMA_TraderEA

### DIFF
--- a/EMA_TraderEA.mq5
+++ b/EMA_TraderEA.mq5
@@ -44,6 +44,16 @@ bool   inRestricted   = false;    // are we in the restricted time?
 string logFilePath = "";          // where to save the trade log
 
 //+------------------------------------------------------------------+
+//| Helper to extract hour from datetime                             |
+//+------------------------------------------------------------------+
+int GetHour(datetime t)
+  {
+   MqlDateTime s;
+   TimeToStruct(t, s);
+   return(s.hour);
+  }
+
+//+------------------------------------------------------------------+
 //| Check if current time is in the restricted window                |
 //+------------------------------------------------------------------+
 bool TradingTimeRestricted()
@@ -53,7 +63,7 @@ bool TradingTimeRestricted()
    int offset      = (int)MathRound((double)(server - utc) / 3600.0); // +2 or +3
    // convert server time to Brisbane (UTC+10)
    datetime bneTime = server + (10 - offset) * 3600;
-   int hourBNE      = TimeHour(bneTime);
+   int hourBNE      = GetHour(bneTime);
 
    int start = (NyCloseBne - 3 + 24) % 24;  // 3h before NY close
    int end   = (NyCloseBne + 3) % 24;       // 3h after


### PR DESCRIPTION
## Summary
- add helper to compute hour from a datetime value
- use this helper instead of missing `TimeHour()` call

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e0c46a760832195c303087cd7e053