### PR TITLE
Improve range calc using bar highs and lows

### DIFF
--- a/FXScanner.mq5
+++ b/FXScanner.mq5
@@ -177,13 +177,20 @@ void PerformScan(const string folderPath, const string timestamp)
                 Print("No ticks for ", symbol, " on ", EnumToString(timeframes[j]));
             }
 
+            // also load bar data for true high/low extremes
+            MqlRates rates[];
+            int rateCount = CopyRates(symbol, timeframes[j], startTime, endTime, rates);
+            if(rateCount <= 0)
+            {
+                Print("No rates for ", symbol, " on ", EnumToString(timeframes[j]));
+            }
+
             // Range calculation
             double high = -DBL_MAX, low = DBL_MAX;
-            for(int k = 0; k < tickCount; k++)
+            for(int k = 0; k < rateCount; k++)
             {
-                double mid = (ticks[k].ask + ticks[k].bid) / 2.0;
-                if(mid > high) high = mid;
-                if(mid < low)  low  = mid;
+                if(rates[k].high > high) high = rates[k].high;
+                if(rates[k].low  < low)  low  = rates[k].low;
             }
             double rangePercent = 0.0;
             if(low < DBL_MAX && high > -DBL_MAX && bidPrice > 0.0)


### PR DESCRIPTION
## Summary
- fetch bar data for each timeframe using `CopyRates`
- compute high and low from `rates[].high` and `rates[].low`
- preserve range percentage calculation with the new extremes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ffaef97088321887b69bba6fa191b