### PR TITLE
Improve FXScanner symbol data loading

### DIFF
--- a/FXScanner.mq5
+++ b/FXScanner.mq5
@@ -139,6 +139,14 @@ void PerformScan(const string folderPath, const string timestamp)
         if(ShowDebugMessages)
             PrintFormat("[%3d%%] Processing symbol (%d/%d): %s", progress, i+1, symbols.Total(), symbol);
 
+        // Ensure the symbol is subscribed so CopyRates can load history
+        if(!SymbolSelect(symbol, true))
+        {
+            Print("Failed to select symbol ", symbol);
+            continue;
+        }
+        RefreshRates();
+
         // --- Swap information ---
         double swapLong, swapShort;
         if(!SymbolInfoDouble(symbol, SYMBOL_SWAP_LONG, swapLong) ||


### PR DESCRIPTION
## Summary
- ensure each symbol is selected before attempting to load historical data
- add a quick rates refresh

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685003568a9083218f7ec2128b7f2af3