### PR TITLE
Delete old CSV files only on first scan

### DIFF
--- a/MT5Scanner.mq5
+++ b/MT5Scanner.mq5
@@ -110,9 +110,11 @@ void OnStart()
     string displayPath = TerminalInfoString(TERMINAL_DATA_PATH) +
                          "\\MQL5\\Files\\" + g_outputFolder;
 
+    // Delete any old CSV files before starting the first scan
+    DeleteOldCsvFiles(g_outputFolder);
+
     while(!IsStopped())
     {
-        DeleteOldCsvFiles(g_outputFolder);
         g_fileTimestamp = GetTimestampString();
         if(ShowDebugMessages)
             Print("Saving reports to ", displayPath, " with timestamp prefix ", g_fileTimestamp);


### PR DESCRIPTION
## Summary
- move CSV cleanup outside scanning loop so it runs only once on startup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a1d3def98832194d2c92df0e9a888