### PR TITLE
Fix correlation matrix label APIs and add colors

### DIFF
--- a/CorrelationMatrixEA.mq5
+++ b/CorrelationMatrixEA.mq5
@@ -11,6 +11,21 @@
 #include <Controls/Dialog.mqh>
 #include <Controls/Label.mqh>
 
+// alignment modes for labels
+enum ALIGN_MODE
+  {
+   ALIGN_LEFT=0,
+   ALIGN_CENTER=1,
+   ALIGN_RIGHT=2
+  };
+
+// basic color definitions
+#define clrDarkSlateGray C'47,79,79'
+#define clrGray          C'128,128,128'
+#define clrLime          C'0,255,0'
+#define clrTomato        C'255,99,71'
+#define clrSilver        C'192,192,192'
+
 CAppDialog  dlg;                     // main dialog window
 CArrayObj   labelGrid;               // holds label objects
 CArrayString symbols;                // list of symbols to display
@@ -80,9 +95,9 @@ void CreateGrid()
          dlg.Add(lab);
          // set label appearance
          // center the label text and set basic colors
-         lab.TextAlign(ALIGN_CENTER);
+         lab.Align(ALIGN_CENTER);
          lab.Color(clrWhite);
-         lab.BackColor((r==0||c==0)?clrDarkSlateGray:clrGray);
+         lab.SetBackColor((r==0||c==0)?clrDarkSlateGray:clrGray);
          if(r==0 && c>0) lab.Text(symbols.At(c-1));
          if(c==0 && r>0) lab.Text(symbols.At(r-1));
        }
@@ -103,11 +118,11 @@ void UpdateMatrix()
          string txt=DoubleToString(corr,2);
          lab.Text(txt);
          if(corr>0.8)        // strong positive correlation
-            lab.BackColor(clrLime);
+            lab.SetBackColor(clrLime);
          else if(corr<-0.8) // strong negative correlation
-            lab.BackColor(clrTomato);
+            lab.SetBackColor(clrTomato);
          else               // weak correlation
-            lab.BackColor(clrSilver);
+            lab.SetBackColor(clrSilver);
         }
      }
   }


### PR DESCRIPTION
## Summary
- fix TextAlign/BackColor compile errors by using Align and SetBackColor
- define simple alignment enum and color macros

## Testing
- `echo "No tests specified"`

------
https://chatgpt.com/codex/tasks/task_e_685a3f2068608321966785c96cb59760