### PR TITLE
Add WeekendCloseEA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# MT5 Utilities
+
+This repository contains various MetaTrader 5 scripts and expert advisors.
+
+## Weekend Close EA
+
+`WeekendCloseEA.mq5` automatically closes all open positions around the end of the trading week.
+
+### Features
+- Runs on any chart and checks every minute (configurable).
+- At 5:00 AM Brisbane time on Saturday, it closes all positions. When the United States is not on daylight saving time, the cutoff shifts to 6:00 AM.
+- Each closed trade is appended to `WeekendCloseLog.csv` in the terminal's `Files` directory.
+
+### Usage
+1. Copy `WeekendCloseEA.mq5` to your **MQL5/Experts** folder and compile it in MetaEditor.
+2. Attach the expert to any chart in MetaTrader 5.
+3. Keep the terminal running so the EA can check the time and close positions automatically.
+

--- a/WeekendCloseEA.mq5
+++ b/WeekendCloseEA.mq5
@@ -1,0 +1,133 @@
+//+------------------------------------------------------------------+
+//|   Weekend Close EA                                               |
+//|   Closes all positions before the weekend                        |
+//+------------------------------------------------------------------+
+#property copyright "2024"
+#property version   "1.00"
+#property strict
+
+#include <Trade/Trade.mqh>
+
+//--- trade object
+CTrade trade;
+
+input int    TimerSeconds   = 60; // interval for timer checks
+input string LogFileName    = "WeekendCloseLog.csv"; // log file
+
+//+------------------------------------------------------------------+
+//| Helper: calculate second Sunday of March                         |
+//+------------------------------------------------------------------+
+datetime SecondSundayMarch(int year)
+  {
+   MqlDateTime dt={0};
+   dt.year=year;
+   dt.mon=3;
+   dt.day=1;
+   datetime d=StructToTime(dt);
+   while(TimeDayOfWeek(d)!=0)
+      d+=86400;
+   d+=7*86400; // second Sunday
+   return d;
+  }
+
+//+------------------------------------------------------------------+
+//| Helper: calculate first Sunday of November                       |
+//+------------------------------------------------------------------+
+datetime FirstSundayNovember(int year)
+  {
+   MqlDateTime dt={0};
+   dt.year=year;
+   dt.mon=11;
+   dt.day=1;
+   datetime d=StructToTime(dt);
+   while(TimeDayOfWeek(d)!=0)
+      d+=86400;
+   return d;
+  }
+
+//+------------------------------------------------------------------+
+//| Check if given time is during US DST                             |
+//+------------------------------------------------------------------+
+bool USDST(datetime t)
+  {
+   MqlDateTime tm; TimeToStruct(t,tm);
+   datetime start=SecondSundayMarch(tm.year);
+   datetime end=FirstSundayNovember(tm.year);
+   return(t>=start && t<end);
+  }
+
+//+------------------------------------------------------------------+
+//| Close all open positions                                         |
+//+------------------------------------------------------------------+
+void CloseAll()
+  {
+   int total=PositionsTotal();
+   for(int i=total-1;i>=0;i--)
+     {
+      ulong ticket=PositionGetTicket(i);
+      string symbol=PositionGetString(POSITION_SYMBOL);
+      double volume=PositionGetDouble(POSITION_VOLUME);
+      double price=PositionGetDouble(POSITION_PRICE_CURRENT);
+
+      if(trade.PositionClose(ticket))
+        {
+         string dateStr=TimeToString(TimeLocal(),TIME_DATE|TIME_MINUTES);
+         FileHandle fh=FileOpen(LogFileName,FILE_READ|FILE_WRITE|FILE_CSV|FILE_ANSI);
+         if(fh!=INVALID_HANDLE)
+           {
+            if(FileSize(fh)==0)
+               FileWrite(fh,"Date","Ticket","Symbol","Volume","Price");
+            FileSeek(fh,0,SEEK_END);
+            FileWrite(fh,dateStr,ticket,symbol,DoubleToString(volume,2),DoubleToString(price,_Digits));
+            FileClose(fh);
+           }
+         Print("Closed ",symbol," ticket ",ticket);
+        }
+      else
+         Print("Failed to close ",symbol," ticket ",ticket,": ",GetLastError());
+     }
+  }
+
+//+------------------------------------------------------------------+
+//| Check time and close if needed                                   |
+//+------------------------------------------------------------------+
+void CheckWeekendClose()
+  {
+   datetime now=TimeLocal();
+   MqlDateTime tm; TimeToStruct(now,tm);
+   if(TimeDayOfWeek(now)==6) // Saturday
+     {
+      bool dst=USDST(now);
+      int cutoff=dst?5:6;
+      if(tm.hour>=cutoff)
+         CloseAll();
+     }
+  }
+
+//+------------------------------------------------------------------+
+//| Expert initialization                                             |
+//+------------------------------------------------------------------+
+int OnInit()
+  {
+   EventSetTimer(TimerSeconds);
+   CheckWeekendClose();
+   return(INIT_SUCCEEDED);
+  }
+
+//+------------------------------------------------------------------+
+//| Expert deinitialization                                           |
+//+------------------------------------------------------------------+
+void OnDeinit(const int reason)
+  {
+   EventKillTimer();
+  }
+
+//+------------------------------------------------------------------+
+//| Timer event handler                                               |
+//+------------------------------------------------------------------+
+void OnTimer()
+  {
+   CheckWeekendClose();
+  }
+
+//+------------------------------------------------------------------+


### PR DESCRIPTION
## Summary
- add WeekendCloseEA expert advisor that closes trades before the weekend
- document usage of the new EA in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fd2b662208321a6746a8ec0981003