### PR TITLE
Fix form reset on page refresh

### DIFF
--- a/ScannerEA.mq5
+++ b/ScannerEA.mq5
@@ -396,7 +396,7 @@ string BuildSpreadSwapHtml()
 
    // Build the HTML page
    string html="<html><head><meta charset='UTF-8'>";
-   html+=StringFormat("<meta http-equiv='refresh' content='%d'>",RefreshSeconds);
+   html+=StringFormat("<script>var refreshTimer=setTimeout(function(){location.reload();},%d000);function stopRefresh(){clearTimeout(refreshTimer);}</script>",RefreshSeconds);
    html+="<style>";
    html+="body{font-family:monospace;background:black;color:white;margin:0;}";
   html+="div.wrapper{display:flex;gap:20px;flex-wrap:wrap;}";
@@ -532,7 +532,7 @@ string BuildSpreadSwapHtml()
   "r+='<tr><td>Net Profit</td><td>'+netReward.toFixed(2)+'</td></tr>';"+
   "if(bro=='oanda'){el('ps_copy_webhook').style.display='block';el('ps_copy_json').style.display='block';}"+
   "document.getElementById('ps_result').innerHTML=r;localStorage.setItem('ps_result',r);saveInputs();updateVis();}"+
-  "window.onload=function(){loadInputs();updateVis();var r=localStorage.getItem('ps_result');if(r)el('ps_result').innerHTML=r;if(localStorage.getItem('ps_last_txt'))el('ps_download').style.display='block';var h=location.hash.substring(1);if(h=='')h='"+TFNames[defaultIndex]+"';showTF(h);var ins=document.querySelectorAll('#ps_form input,#ps_form select');for(var i=0;i<ins.length;i++)ins[i].addEventListener('change',function(){saveInputs();updateVis();});};"+
+  "window.onload=function(){loadInputs();updateVis();var r=localStorage.getItem('ps_result');if(r)el('ps_result').innerHTML=r;if(localStorage.getItem('ps_last_txt'))el('ps_download').style.display='block';var h=location.hash.substring(1);if(h=='')h='"+TFNames[defaultIndex]+"';showTF(h);var ins=document.querySelectorAll('#ps_form input,#ps_form select');for(var i=0;i<ins.length;i++){ins[i].addEventListener('input',function(){stopRefresh();saveInputs();updateVis();});ins[i].addEventListener('change',function(){stopRefresh();saveInputs();updateVis();});}window.addEventListener('beforeunload',saveInputs);};"+
   "</script></body></html>";
   return html;
  }


### PR DESCRIPTION
## Summary
- add JS timer so auto-refresh can be cancelled
- stop refresh when user edits form

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68634345d37083219ff51612e060aca0