### PR TITLE
Allow choosing EMA for price bounce and fix indicator warning

### DIFF
--- a/Backtester.mq5
+++ b/Backtester.mq5
@@ -430,7 +430,7 @@ int OnInit()
    // so the EA draws only its own moving averages.
    int total=ChartIndicatorsTotal(0,0);    // count how many indicators are on the main chart window
    for(int i=total-1;i>=0;i--)             // loop backward through the indicators
-      ChartIndicatorDelete(0,0,i);         // remove each indicator
+      ChartIndicatorDelete(0,0,ChartIndicatorName(0,0,i)); // remove each indicator by name
 
    maFastHandle = iMA(_Symbol,_Period,FastEMA,0,MODE_EMA,PRICE_CLOSE);
    if(maFastHandle==INVALID_HANDLE)

--- a/EMA_TraderEA.mq5
+++ b/EMA_TraderEA.mq5
@@ -17,6 +17,7 @@ CiMA    maSlow;
 input group "Live trading options";
 input int    FastEMA     = 9;      // fast EMA period
 input int    SlowEMA     = 20;     // slow EMA period
+input bool   BounceFromFast = true; // true = bounce from FastEMA, false = from SlowEMA
 input double NearPct     = 0.5;    // allowed distance from EMA (%)
 input double RiskAUD     = 10.0;   // risk per trade in AUD
 input int    StopPips    = 15;     // stop loss in pips
@@ -381,11 +382,11 @@ void ExecuteTrade()
    double slow = maSlow.Main(0);
    if(fast <= 0 || fast == DBL_MAX || slow <= 0 || slow == DBL_MAX)
       return;
-
+   double bounce = BounceFromFast ? fast : slow;
    if(fast > slow)
-      CheckBuy(fast);
+      CheckBuy(bounce);
    else if(fast < slow)
-      CheckSell(fast);
+      CheckSell(bounce);
   }
 
 //+------------------------------------------------------------------+


### PR DESCRIPTION
## Summary
- Delete indicators by name instead of index to remove implicit number-to-string conversion warning
- Add BounceFromFast option so traders can choose which EMA price must touch before entering a trade

## Testing
- `mql5_compiler Backtester.mq5` *(fails: command not found)*
- `mql5_compiler EMA_TraderEA.mq5` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa86c538588321b212142ced8c8d4c